### PR TITLE
fix(script): 注释掉无用命令及代码、固定ci中golangci-lint的版本使其与setup.sh中版本保持一致

### DIFF
--- a/.CHANGELOG.md
+++ b/.CHANGELOG.md
@@ -35,6 +35,7 @@
 - [merger: 使用 sqlx.Scanner 来读取数据](https://github.com/ecodeclub/eorm/pull/216)
 - [rows, merger: 使用 sqlx.Rows 作为接口，并重构 merger 包 ](https://github.com/ecodeclub/eorm/pull/217)
 - [rows: 同库事务语句合并执行，提前读取所有数据](https://github.com/ecodeclub/eorm/pull/219)
+- [script: 注释掉无用命令及代码、固定ci中golangci-lint的版本使其与setup.sh中版本保持一致](https://github.com/ecodeclub/eorm/pull/220)
 ## v0.0.1:
 - [Init Project](https://github.com/ecodeclub/eorm/pull/1)
 - [Selector Definition](https://github.com/ecodeclub/eorm/pull/2)

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,7 +39,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          version: "v1.52.2"
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/internal/datasource/transaction/delay_transaction_test.go
+++ b/internal/datasource/transaction/delay_transaction_test.go
@@ -488,6 +488,8 @@ func (s *TestDelayTxTestSuite) TestExecute_Commit_Or_Rollback() {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			s.SetupTest()
+
 			tc.mockOrder(s.mockMaster, s.mockMaster2)
 			tx, err := tc.txFunc()
 			require.NoError(t, err)
@@ -508,6 +510,8 @@ func (s *TestDelayTxTestSuite) TestExecute_Commit_Or_Rollback() {
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantAffected, affected)
 			tc.afterFunc(t, tx, values)
+
+			s.TearDownTest()
 		})
 	}
 }

--- a/script/integrate_test.sh
+++ b/script/integrate_test.sh
@@ -3,6 +3,6 @@
 set -e
 docker compose -f script/integration_test_compose.yml down
 docker compose -f script/integration_test_compose.yml up -d
-echo "127.0.0.1 slave.a.com" >> /etc/hosts
+#sudo echo "127.0.0.1 slave.a.com" >> /etc/hosts
 go test -timeout=30m -race ./... -tags=e2e
 docker compose -f script/integration_test_compose.yml down

--- a/sharding_select.go
+++ b/sharding_select.go
@@ -16,7 +16,6 @@ package eorm
 
 import (
 	"context"
-	"sync"
 
 	"github.com/ecodeclub/eorm/internal/merger/batchmerger"
 
@@ -30,7 +29,7 @@ type ShardingSelector[T any] struct {
 	shardingSelectorBuilder
 	table *T
 	db    Session
-	lock  sync.Mutex
+	// lock  sync.Mutex
 }
 
 func NewShardingSelector[T any](db Session) *ShardingSelector[T] {


### PR DESCRIPTION
1. 注释掉script中无用命令
2. 注释掉未使用的lock
3. 固定ci中golangci-lint的版本, 修复因版本不同导致ci失败
4. 修复测代码中的偶发性失败